### PR TITLE
fix : add all constructors for stored procedure commands/queries

### DIFF
--- a/FluidDbClient/src/FluidDbClient.Sql/FluidDbClient.Sql.csproj
+++ b/FluidDbClient/src/FluidDbClient.Sql/FluidDbClient.Sql.csproj
@@ -27,10 +27,6 @@
     <DefineConstants>$(DefineConstants);COREFX</DefineConstants>
   </PropertyGroup>
 
-  <Target Name="PostcompileScript" AfterTargets="Build" Condition=" '$(IsCrossTargetingBuild)' != 'true' ">
-    <Exec Command="dotnet pack --no-build --configuration Release" />
-  </Target>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
     <PackageReference Include="System.Linq.Expressions" Version="4.3.0" />

--- a/FluidDbClient/src/FluidDbClient/Controls/ManagedDbCommand/ManagedDbCommand.cs
+++ b/FluidDbClient/src/FluidDbClient/Controls/ManagedDbCommand/ManagedDbCommand.cs
@@ -27,7 +27,7 @@ namespace FluidDbClient
             _usingExternalResources = connection != null;
         }
 
-        // --- Connection and transaction managed externally via DbSessionBase ---
+        // --- Connection and transaction managed externally ---
         protected ManagedDbCommand(Database database, DbTransaction transaction, object parameters)
             : base(database, transaction, parameters)
         {

--- a/FluidDbClient/src/FluidDbClient/Controls/ManagedDbCommand/ManagedDbCommand.cs
+++ b/FluidDbClient/src/FluidDbClient/Controls/ManagedDbCommand/ManagedDbCommand.cs
@@ -7,23 +7,27 @@ namespace FluidDbClient
     {
         private bool _usingExternalResources;
         private bool _isCommitted;
-        
+
+        // --- Connection and transaction managed internally ---
         protected ManagedDbCommand(Database database, object parameters) 
             : base(database, parameters)
         { }
 
+        // --- Connection and transaction managed externally via DbSessionBase ---
         protected ManagedDbCommand(Database database, DbSessionBase session, object parameters)
             : base(database, session, parameters)
         {
             _usingExternalResources = session != null;
         }
 
+        // --- Connection managed externally ---
         protected ManagedDbCommand(Database database, DbConnection connection, object parameters)
             : base(database, connection, parameters)
         {
             _usingExternalResources = connection != null;
         }
 
+        // --- Connection and transaction managed externally via DbSessionBase ---
         protected ManagedDbCommand(Database database, DbTransaction transaction, object parameters)
             : base(database, transaction, parameters)
         {

--- a/FluidDbClient/src/FluidDbClient/Controls/ManagedDbCommand/StoredProcedureDbCommand.cs
+++ b/FluidDbClient/src/FluidDbClient/Controls/ManagedDbCommand/StoredProcedureDbCommand.cs
@@ -1,13 +1,30 @@
 ﻿using System.Data;
+using System.Data.Common;
 
 namespace FluidDbClient
 {
-    // TODO: more constructor options
-
     public abstract class StoredProcedureDbCommandBase : ManagedDbCommand
     {
+        protected StoredProcedureDbCommandBase(Database database, string storedProcedureName, object parameters) 
+            : base(database, parameters)
+        {
+            StoredProcedureName = storedProcedureName;
+        }
+
         protected StoredProcedureDbCommandBase(Database database, DbSessionBase session, string storedProcedureName, object parameters)
             : base(database, session, parameters)
+        {
+            StoredProcedureName = storedProcedureName;
+        }
+        
+        protected StoredProcedureDbCommandBase(Database database, DbConnection connection, string storedProcedureName, object parameters)
+            : base(database, connection, parameters)
+        {
+            StoredProcedureName = storedProcedureName;
+        }
+
+        protected StoredProcedureDbCommandBase(Database database, DbTransaction transaction, string storedProcedureName, object parameters)
+            : base(database, transaction, parameters)
         {
             StoredProcedureName = storedProcedureName;
         }
@@ -26,24 +43,40 @@ namespace FluidDbClient
 
     public class StoredProcedureDbCommand : StoredProcedureDbCommandBase
     {
+        public StoredProcedureDbCommand(string storedProcedureName, object parameters = null)
+            : base(DbRegistry.GetDatabase(), storedProcedureName, parameters)
+        { }
+
         public StoredProcedureDbCommand(DbSessionBase session, string storedProcedureName, object parameters = null) 
             : base(DbRegistry.GetDatabase(), session, storedProcedureName, parameters)
         { }
 
-        public StoredProcedureDbCommand(string storedProcedureName, object parameters = null)
-            : this(null, storedProcedureName, parameters)
+        public StoredProcedureDbCommand(DbConnection connection, string storedProcedureName, object parameters = null)
+            : base(DbRegistry.GetDatabase(), connection, storedProcedureName, parameters)
+        { }
+
+        public StoredProcedureDbCommand(DbTransaction transaction, string storedProcedureName, object parameters = null)
+            : base(DbRegistry.GetDatabase(), transaction, storedProcedureName, parameters)
         { }
     }
 
 
     public class StoredProcedureDbCommand<TDatabase> : StoredProcedureDbCommandBase where TDatabase : Database
     {
-        public StoredProcedureDbCommand(DbSessionBase session, string storedProcedureName, object parameters = null)
-                    : base(DbRegistry.GetDatabase<TDatabase>(), session, storedProcedureName, parameters)
+        public StoredProcedureDbCommand(string storedProcedureName, object parameters = null)
+            : base(DbRegistry.GetDatabase<TDatabase>(), storedProcedureName, parameters)
         { }
 
-        public StoredProcedureDbCommand(string storedProcedureName, object parameters = null)
-            : this(null, storedProcedureName, parameters)
+        public StoredProcedureDbCommand(DbSessionBase session, string storedProcedureName, object parameters = null)
+            : base(DbRegistry.GetDatabase<TDatabase>(), session, storedProcedureName, parameters)
+        { }
+
+        public StoredProcedureDbCommand(DbConnection connection, string storedProcedureName, object parameters = null)
+            : base(DbRegistry.GetDatabase<TDatabase>(), connection, storedProcedureName, parameters)
+        { }
+        
+        public StoredProcedureDbCommand(DbTransaction transaction, string storedProcedureName, object parameters = null)
+            : base(DbRegistry.GetDatabase<TDatabase>(), transaction, storedProcedureName, parameters)
         { }
     }
 }

--- a/FluidDbClient/src/FluidDbClient/Controls/ManagedDbControl.cs
+++ b/FluidDbClient/src/FluidDbClient/Controls/ManagedDbControl.cs
@@ -16,6 +16,7 @@ namespace FluidDbClient
         private readonly string _typeName;
         private readonly Dictionary<string, DbParameter> _parameters = new Dictionary<string, DbParameter>(StringComparer.OrdinalIgnoreCase);
 
+        // --- Connection and transaction managed internally ---
         protected ManagedDbControl(Database database, object parameters)
         {
             Timeout = 60;
@@ -30,18 +31,21 @@ namespace FluidDbClient
             mappedParams.ForEach(p => this[p.Key] = p.Value);
         }
 
+        // --- Connection and transaction managed externally via DbSessionBase ---
         protected ManagedDbControl(Database database, DbSessionBase session, object parameters) 
             : this(database, parameters)
         {
             _session = session;
         }
 
+        // --- Connection managed externally ---
         protected ManagedDbControl(Database database, DbConnection connection, object parameters)
             : this(database, parameters)
         {
             Connection = connection;
         }
 
+        // --- Connection and transaction managed externally ---
         protected ManagedDbControl(Database database, DbTransaction transaction, object parameters)
             : this(database, parameters)
         {

--- a/FluidDbClient/src/FluidDbClient/Controls/ManagedDbQuery/ManagedDbQuery.cs
+++ b/FluidDbClient/src/FluidDbClient/Controls/ManagedDbQuery/ManagedDbQuery.cs
@@ -11,22 +11,26 @@ namespace FluidDbClient
         private readonly bool _usingExternalResources;
         private DbDataReader _reader;
 
+        // --- Connection and transaction managed internally ---
         protected ManagedDbQuery(Database database, object parameters) 
             : base(database, parameters)
         { }
 
+        // --- Connection and transaction managed externally via DbSessionBase ---
         protected ManagedDbQuery(Database database, DbSessionBase session, object parameters)
             : base(database, session, parameters)
         {
             _usingExternalResources = session != null;
         }
 
+        // --- Connection managed externally ---
         protected ManagedDbQuery(Database database, DbConnection connection, object parameters)
             : base(database, connection, parameters)
         {
             _usingExternalResources = connection != null;
         }
 
+        // --- Connection and transaction managed externally ---
         protected ManagedDbQuery(Database database, DbTransaction transaction, object parameters)
             : base(database, transaction, parameters)
         {

--- a/FluidDbClient/src/FluidDbClient/Controls/ManagedDbQuery/StoredProcedureDbQuery.cs
+++ b/FluidDbClient/src/FluidDbClient/Controls/ManagedDbQuery/StoredProcedureDbQuery.cs
@@ -1,13 +1,30 @@
 ﻿using System.Data;
+using System.Data.Common;
 
 namespace FluidDbClient
 {
-    // TODO: more constructor options
-
     public abstract class StoredProcedureDbQueryBase : ManagedDbQuery
     {
+        protected StoredProcedureDbQueryBase(Database database, string storedProcedureName, object parameters) 
+            : base(database, parameters)
+        {
+            StoredProcedureName = storedProcedureName;
+        }
+
         protected StoredProcedureDbQueryBase(Database database, DbSessionBase session, string storedProcedureName, object parameters) 
             : base(database, session, parameters)
+        {
+            StoredProcedureName = storedProcedureName;
+        }
+
+        protected StoredProcedureDbQueryBase(Database database, DbConnection connection, string storedProcedureName, object parameters)
+            : base(database, connection, parameters)
+        {
+            StoredProcedureName = storedProcedureName;
+        }
+
+        protected StoredProcedureDbQueryBase(Database database, DbTransaction transaction, string storedProcedureName, object parameters)
+            : base(database, transaction, parameters)
         {
             StoredProcedureName = storedProcedureName;
         }
@@ -26,23 +43,39 @@ namespace FluidDbClient
 
     public class StoredProcedureDbQuery : StoredProcedureDbQueryBase
     {
+        public StoredProcedureDbQuery(string storedProcedureName, object parameters = null) 
+            : base(DbRegistry.GetDatabase(), storedProcedureName, parameters)
+        { }
+
         public StoredProcedureDbQuery(DbSessionBase session, string storedProcedureName, object parameters = null) 
             : base(DbRegistry.GetDatabase(), session, storedProcedureName, parameters)
         { }
 
-        public StoredProcedureDbQuery(string storedProcedureName, object parameters = null) 
-            : this(null, storedProcedureName, parameters)
+        public StoredProcedureDbQuery(DbConnection connection, string storedProcedureName, object parameters = null)
+            : base(DbRegistry.GetDatabase(), connection, storedProcedureName, parameters)
+        { }
+
+        public StoredProcedureDbQuery(DbTransaction transaction, string storedProcedureName, object parameters = null)
+            : base(DbRegistry.GetDatabase(), transaction, storedProcedureName, parameters)
         { }
     }
 
     public class StoredProcedureDbQuery<TDatabase> : StoredProcedureDbQueryBase where TDatabase : Database
     {
+        public StoredProcedureDbQuery(string storedProcedureName, object parameters = null)
+            : base(DbRegistry.GetDatabase<TDatabase>(), storedProcedureName, parameters)
+        { }
+
         public StoredProcedureDbQuery(DbSessionBase session, string storedProcedureName, object parameters = null)
             : base(DbRegistry.GetDatabase<TDatabase>(), session, storedProcedureName, parameters)
         { }
 
-        public StoredProcedureDbQuery(string storedProcedureName, object parameters = null)
-            : this(null, storedProcedureName, parameters)
+        public StoredProcedureDbQuery(DbConnection connection, string storedProcedureName, object parameters = null)
+            : base(DbRegistry.GetDatabase<TDatabase>(), connection, storedProcedureName, parameters)
+        { }
+
+        public StoredProcedureDbQuery(DbTransaction transaction, string storedProcedureName, object parameters = null)
+            : base(DbRegistry.GetDatabase<TDatabase>(), transaction, storedProcedureName, parameters)
         { }
     }
 }

--- a/FluidDbClient/src/FluidDbClient/FluidDbClient.csproj
+++ b/FluidDbClient/src/FluidDbClient/FluidDbClient.csproj
@@ -23,10 +23,6 @@
     <DefineConstants>$(DefineConstants);COREFX</DefineConstants>
   </PropertyGroup>
 
-  <Target Name="PostcompileScript" AfterTargets="Build" Condition=" '$(IsCrossTargetingBuild)' != 'true' ">
-    <Exec Command="dotnet pack --no-build --configuration Release" />
-  </Target>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />


### PR DESCRIPTION
1) This fixes the root cause of the stored procedure connection leak.  

2) removed post-compile script section of both csproj's due to frequent pack conflicts.  

The previously added line accomplishes this:
{<}GeneratePackageOnBuild{>}true{</}/GeneratePackageOnBuild{>}